### PR TITLE
Update README.md - Fix building of binaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ make
 ### Build coreboot
 ```
 cd bootloader/coreboot
-make nintendo-switch_defconfig
+make nintendo_switch_defconfig
 make iasl
 make
 ```

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ make
 ### Build u-boot
 ```
 cd bootloader/u-boot
-make nintendo_switch_defconfig
+make nintendo-switch_defconfig
 make
 ```
 


### PR DESCRIPTION
The file in the `configs/` folder is `configs/nintendo-switch_defconfig` instead of the README suggested `nintendo_switch_defconfig`